### PR TITLE
Don't initialize a group in setUpAll/tearDownAll.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.8+1
+
+* Make `setUpAll()` and `tearDownAll()` work with normal `setUp()` and
+  `tearDown()` calls.
+
 ## 0.12.8
 
 * Support scheduling in `setUpAll()` and `tearDownAll()`.

--- a/lib/scheduled_test.dart
+++ b/lib/scheduled_test.dart
@@ -118,7 +118,6 @@ void setUpAll(body()) {
     if (future != null) test_pkg.expect(future, test_pkg.completes);
   }
 
-  _initializeForGroup();
   test_pkg.setUpAll(() {
     _currentSchedule = new Schedule();
     return currentSchedule.run(() {
@@ -143,7 +142,6 @@ void tearDownAll(body()) {
     if (future != null) test_pkg.expect(future, test_pkg.completes);
   }
 
-  _initializeForGroup();
   test_pkg.tearDownAll(() {
     _currentSchedule = new Schedule();
     return currentSchedule.run(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scheduled_test
-version: 0.12.8
+version: 0.12.8+1
 author: Dart Team <misc@dartlang.org>
 description: >
   A package for writing readable tests of asynchronous behavior.


### PR DESCRIPTION
This initialized setUp/tearDown, which aren't used for
setUpAll/tearDownAll, and broke the common case where
setUpAll/tearDownAll are called before setUp/tearDown.