### PR TITLE
Fix most strong mode errors in lib/; LineSplitter issue remains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.12.11
+
+* Fix most strong mode errors and warnings.
+* Support `test` version `0.12.20`
+* Minimum Dart SDK version is now `1.22.0`.
+
 ## 0.12.10+1
 
 * Hide the `StreamMatcher` class from the `test` package.

--- a/lib/scheduled_test.dart
+++ b/lib/scheduled_test.dart
@@ -174,8 +174,8 @@ void tearDownAll(body()) {
 /// on the next event loop iteration rather than adding it to a queue. The
 /// current task will not complete until [fn] (and any [Future] it returns) has
 /// finished running.
-Future/*<T>*/ schedule/*<T>*/(/*=T*/ fn(), [String description]) =>
-  currentSchedule.tasks.schedule(fn, description);
+Future<T> schedule<T>(T fn(), [String description]) =>
+  (currentSchedule.tasks as TaskQueue<T>).schedule(fn, description);
 
 /// Register a [setUp] function for a test [group].
 ///

--- a/lib/scheduled_test.dart
+++ b/lib/scheduled_test.dart
@@ -175,7 +175,7 @@ void tearDownAll(body()) {
 /// current task will not complete until [fn] (and any [Future] it returns) has
 /// finished running.
 Future<T> schedule<T>(T fn(), [String description]) =>
-  (currentSchedule.tasks as TaskQueue<T>).schedule(fn, description);
+  currentSchedule.tasks.schedule(fn, description);
 
 /// Register a [setUp] function for a test [group].
 ///

--- a/lib/src/descriptor/file_descriptor.dart
+++ b/lib/src/descriptor/file_descriptor.dart
@@ -141,9 +141,8 @@ class _MatcherFileDescriptor extends FileDescriptor {
       : _isBinary = isBinary == true ? true : false,
         super._(name, <int>[]);
 
-  void _validateNow(List<int> actualContents) {
+  void _validateNow(List<int> actualContents) =>
       expect(
           _isBinary ? actualContents : new String.fromCharCodes(actualContents),
           _matcher);
-  }
 }

--- a/lib/src/descriptor/file_descriptor.dart
+++ b/lib/src/descriptor/file_descriptor.dart
@@ -141,8 +141,9 @@ class _MatcherFileDescriptor extends FileDescriptor {
       : _isBinary = isBinary == true ? true : false,
         super._(name, <int>[]);
 
-  void _validateNow(List<int> actualContents) =>
+  void _validateNow(List<int> actualContents) {
       expect(
           _isBinary ? actualContents : new String.fromCharCodes(actualContents),
           _matcher);
+  }
 }

--- a/lib/src/schedule.dart
+++ b/lib/src/schedule.dart
@@ -17,11 +17,11 @@ import 'utils.dart';
 ///
 /// This has two task queues: [tasks] and [onComplete]. It also provides
 /// visibility into the current state of the schedule.
-class Schedule<T> {
+class Schedule {
   /// The main task queue for the schedule. These tasks are run before the other
   /// queues and generally constitute the main test body.
-  TaskQueue<T> get tasks => _tasks;
-  TaskQueue<T> _tasks;
+  TaskQueue get tasks => _tasks;
+  TaskQueue _tasks;
 
   /// The queue of tasks to run after [tasks] has run. This queue will run
   /// whether or not an error occurred. If one did, it will be available in
@@ -29,14 +29,14 @@ class Schedule<T> {
   ///
   /// If an error occurs in a task in this queue, all further tasks will be
   /// skipped.
-  TaskQueue<T> get onComplete => _onComplete;
-  TaskQueue<T> _onComplete;
+  TaskQueue get onComplete => _onComplete;
+  TaskQueue _onComplete;
 
   /// Returns the [Task] that's currently executing, or `null` if there is no
   /// such task. This will be `null` both before the schedule starts running and
   /// after it's finished.
-  Task<T> get currentTask => _currentTask;
-  Task<T> _currentTask;
+  Task get currentTask => _currentTask;
+  Task _currentTask;
 
   /// The current state of the schedule.
   ScheduleState get state => _state;
@@ -63,14 +63,14 @@ class Schedule<T> {
   ///
   /// One of [tasks] or [onComplete]. This starts as [tasks], and can only be
   /// `null` after the schedule is done.
-  TaskQueue<T> get currentQueue =>
+  TaskQueue get currentQueue =>
     _state == ScheduleState.DONE ? null : _currentQueue;
-  TaskQueue<T> _currentQueue;
+  TaskQueue _currentQueue;
 
   /// Creates a new schedule with empty task queues.
   Schedule() {
-    _tasks = new TaskQueue<T>._("tasks", this);
-    _onComplete = new TaskQueue<T>._("onComplete", this);
+    _tasks = new TaskQueue._("tasks", this);
+    _onComplete = new TaskQueue._("onComplete", this);
     _currentQueue = _tasks;
   }
 
@@ -180,16 +180,16 @@ class ScheduleState {
 }
 
 /// A queue of asynchronous tasks to execute in order.
-class TaskQueue<T> {
+class TaskQueue {
   /// The tasks in the queue.
-  List<Task<T>> get contents => new UnmodifiableListView<Task<T>>(_contents);
-  final _contents = new Queue<Task<T>>();
+  List<Task> get contents => new UnmodifiableListView<Task>(_contents);
+  final _contents = new Queue<Task>();
 
   /// The name of the queue, for debugging purposes.
   final String name;
 
   /// The [Schedule] that created this queue.
-  final Schedule<T> _schedule;
+  final Schedule _schedule;
 
   /// Whether to stop running after the current task.
   bool _aborted = false;
@@ -220,7 +220,7 @@ class TaskQueue<T> {
   /// known as a "nested task". The current task will not complete until [fn]
   /// (and any [Future] it returns) has finished running. Nested tasks run in
   /// parallel, unlike top-level tasks which run in sequence.
-  Future<T> schedule(T fn(), [String description]) {
+  Future<T> schedule<T>(T fn(), [String description]) {
     if (isRunning) {
       var task = _schedule.currentTask;
       TaskBody<T> wrappedFn = () {

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -32,7 +32,7 @@ class Task<T> {
   /// A [FutureGroup] that will complete once all current child tasks are
   /// finished running. This will be null if no child tasks are currently
   /// running.
-  FutureGroup _childGroup;
+  FutureGroup<T> _childGroup;
 
   /// A description of this task. Used for debugging. May be `null`.
   final String description;
@@ -76,7 +76,7 @@ class Task<T> {
       }
 
       _state = TaskState.RUNNING;
-      var future = new Future<T>.sync(fn).then((value) {
+      var future = new Future<T>.sync(fn).then<T>((value) {
         if (_childGroup == null || _childGroup.completed) return value;
         return _childGroup.future.then((_) => value);
       });
@@ -94,8 +94,8 @@ class Task<T> {
   /// Run [fn] as a child of this task. Returns a Future that will complete with
   /// the result of the child task. This task will not complete until [fn] has
   /// finished.
-  Future/*<S>*/ runChild/*<S>*/(/*=S*/ fn(), String description) {
-    var task = new Task/*<S>*/._child(fn, description, this);
+  Future<T> runChild(TaskBody fn, String description) {
+    var task = new Task<T>._child(fn, description, this);
     _children.add(task);
     if (_childGroup == null || _childGroup.completed) {
       _childGroup = new FutureGroup();

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -94,7 +94,7 @@ class Task<T> {
   /// Run [fn] as a child of this task. Returns a Future that will complete with
   /// the result of the child task. This task will not complete until [fn] has
   /// finished.
-  Future<S> runChild<S>(TaskBody<S> fn, String description) {
+  Future<S> runChild<S>(Future<S> fn(), String description) {
     var task = new Task<S>._child(fn, description, this);
     _children.add(task);
     if (_childGroup == null || _childGroup.completed) {

--- a/lib/src/task.dart
+++ b/lib/src/task.dart
@@ -32,7 +32,7 @@ class Task<T> {
   /// A [FutureGroup] that will complete once all current child tasks are
   /// finished running. This will be null if no child tasks are currently
   /// running.
-  FutureGroup<T> _childGroup;
+  FutureGroup _childGroup;
 
   /// A description of this task. Used for debugging. May be `null`.
   final String description;
@@ -94,8 +94,8 @@ class Task<T> {
   /// Run [fn] as a child of this task. Returns a Future that will complete with
   /// the result of the child task. This task will not complete until [fn] has
   /// finished.
-  Future<T> runChild(TaskBody fn, String description) {
-    var task = new Task<T>._child(fn, description, this);
+  Future<S> runChild<S>(TaskBody<S> fn, String description) {
+    var task = new Task<S>._child(fn, description, this);
     _children.add(task);
     if (_childGroup == null || _childGroup.completed) {
       _childGroup = new FutureGroup();

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -258,8 +258,8 @@ String terseTraceString(StackTrace trace) {
   return new Chain.forTrace(trace).terse.toString().trim();
 }
 
-StreamTransformer/*<S2, T2>*/ converterTransformer/*<S1, T1, S2, T2>*/(
-    ChunkedConverter/*<S1, T1, S2, T2>*/ converter) {
+StreamTransformer<S, T> converterTransformer<S, T>(
+    Converter<S, T> converter) {
   return new StreamTransformer((stream, cancelOnError) {
     return converter.bind(stream).listen(null, cancelOnError: cancelOnError);
   });

--- a/lib/src/value_future.dart
+++ b/lib/src/value_future.dart
@@ -28,9 +28,9 @@ class ValueFuture<T> implements Future<T> {
   }
 
   Stream<T> asStream() => _future.asStream();
-  Future catchError(Function onError, {bool test(Object error)}) =>
+  Future<T> catchError(Function onError, {bool test(Object error)}) =>
     _future.catchError(onError, test: test);
-  Future/*<S>*/ then/*<S>*/(/*=S*/ onValue(T value), {Function onError}) =>
+  Future<S> then<S>(FutureOr<S> onValue(T value), {Function onError}) =>
     _future.then(onValue, onError: onError);
   Future<T> whenComplete(action()) => _future.whenComplete(action);
   Future<T> timeout(Duration timeLimit, {void onTimeout()}) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: scheduled_test
-version: 0.12.10+1
+version: 0.12.11
 author: Dart Team <misc@dartlang.org>
 description: >
   A package for writing readable tests of asynchronous behavior.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ description: >
 
 homepage: https://github.com/dart-lang/scheduled_test
 environment:
-  sdk: '>=1.16.0 <2.0.0'
+  sdk: '>=1.22.0 <2.0.0'
 dependencies:
   async: '^1.10.0'
   collection: '^1.5.0'
@@ -23,7 +23,7 @@ dependencies:
   # Because scheduled_test exports test, it needs to keep its version constraint
   # tight to ensure that a constraint on scheduled_test properly constraints all
   # features it provides.
-  test: '>=0.12.19 <0.12.20'
+  test: '>=0.12.20 <0.12.21'
 dev_dependencies:
   metatest: "^0.2.1"
   shelf_web_socket: "^0.2.0"


### PR DESCRIPTION
Fixes #32 

Several issues to note during review:

* Schedule and TaskQueue take a type parameter. This is because TaskQueue.schedule is expected to take a function of T, the type that `task.runChild` returns a Future of. Hopefully this isn't like, an external, breaking change? If it is too invasive, let me know how else to fix. (Can maybe just use `as`, though dirty...)
* tossed the (deprecated) ChunkedConverter for Converter. 

Maybe others...

One more Strong mode issue remains. LineSplitter doesn't fit where it is... not sure how to fix right now.