### PR TITLE
Migrate deprecated expectAsync calls to expectAsync1

### DIFF
--- a/test/scheduled_server_test.dart
+++ b/test/scheduled_server_test.dart
@@ -195,7 +195,7 @@ void main() {
       }(), completes);
     });
 
-    server.handle("GET", "/", webSocketHandler(expectAsync((webSocket) {
+    server.handle("GET", "/", webSocketHandler(expectAsync1((webSocket) {
       expect(webSocket.stream.first, completion(equals("hello")));
     })));
   });

--- a/test/scheduled_test/current_schedule_errors_test.dart
+++ b/test/scheduled_test/current_schedule_errors_test.dart
@@ -26,17 +26,17 @@ void main() {
 
   expectTestFailure('currentSchedule.errors contains an error passed into '
       'registerException out-of-band', () {
-    pumpEventQueue().then(expectAsync((_) => registerException('error')));
+    pumpEventQueue().then(expectAsync1((_) => registerException('error')));
   }, (error) => expect(error, equals('error')));
 
   expectTestFailure('currentSchedule.errors contains only the first '
       'out-of-band error from the main task queue in onComplete', () {
     mockClock.run();
 
-    sleep(1).then(expectAsync((_) {
+    sleep(1).then(expectAsync1((_) {
       throw 'error1';
     }));
-    sleep(2).then(expectAsync((_) {
+    sleep(2).then(expectAsync1((_) {
       throw 'error2';
     }));
   }, (error) => expect(error, equals('error1')));

--- a/test/scheduled_test/on_complete_test.dart
+++ b/test/scheduled_test/on_complete_test.dart
@@ -31,7 +31,7 @@ void main() {
         expect(outOfBandRun, isTrue);
       });
 
-      pumpEventQueue().then(expectAsync((_) {
+      pumpEventQueue().then(expectAsync1((_) {
         outOfBandRun = true;
       }));
     });
@@ -45,12 +45,12 @@ void main() {
       currentSchedule.onComplete.schedule(() {
         expect(outOfBand1Run, isTrue);
 
-        pumpEventQueue().then(expectAsync((_) {
+        pumpEventQueue().then(expectAsync1((_) {
           outOfBand2Run = true;
         }));
       });
 
-      pumpEventQueue().then(expectAsync((_) {
+      pumpEventQueue().then(expectAsync1((_) {
         outOfBand1Run = true;
       }));
     });
@@ -61,7 +61,7 @@ void main() {
   expectTestFailure('an out-of-band callback in the onComplete queue blocks '
       'the test', () {
     currentSchedule.onComplete.schedule(() {
-      pumpEventQueue().then(expectAsync((_) => throw 'error'));
+      pumpEventQueue().then(expectAsync1((_) => throw 'error'));
     });
   }, (error) => expect(error, equals('error')));
 
@@ -103,7 +103,7 @@ void main() {
         onCompleteRun = true;
       });
 
-      pumpEventQueue().then(expectAsync((_) => expect('foo', equals('bar'))));
+      pumpEventQueue().then(expectAsync1((_) => expect('foo', equals('bar'))));
     });
 
     test('test 2', () {


### PR DESCRIPTION
This removes all dartanalyzer warnings from the test/ directory (it was just this one).